### PR TITLE
Removed the platform-dependent backslash path separator

### DIFF
--- a/Module/LDIF.psm1
+++ b/Module/LDIF.psm1
@@ -78,7 +78,7 @@ Function Get-LDIFRecords
 	)
 
 	$Script:lineNo = 0
-	$path = "$(pwd)\$InputFile"
+	$path = (Get-Item -LiteralPath $InputFile).FullName
 	$file = New-Object System.IO.StreamReader -Arg $path
 	if(!$file){
 		throw "Can't open $InputFile"


### PR DESCRIPTION
Got this to work in PowerShell 7 on macOS by using better logic for deriving the absolute path of the input file.